### PR TITLE
Error handle notification for corrupted files

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -19,6 +19,7 @@
       </div>
 
       <div class="content">
+        <div class="hidden-editor" style="display: none;"></div>
         <aside>
           <div class="sidebar">
             <div id="tree"></div>

--- a/src/renderer/editor.js
+++ b/src/renderer/editor.js
@@ -23,7 +23,7 @@ const hasChanges = function hasChanges() {
     store.set('changes', true);
     localHasChanges = true;
   }
-  document.title = path.basename(activeFile) + " *";
+  document.title = `${path.basename(activeFile)} *`;
   footer.hasChanges();
 };
 
@@ -116,7 +116,7 @@ module.exports = {
         quill.setContents(delta, 'silent');
       } catch (error) {
         // File is not JSON
-        throw new Error('File is not in JSON format.');
+        console.warn(`${p} is corrupted`);
       }
     }
   },
@@ -210,7 +210,8 @@ module.exports = {
     try {
       module.exports.read(p);
     } catch (error) {
-      throw new Error(error);
+      console.error(`Can not open file.\n${p}`);
+      return false;
     }
 
     // Update the active file

--- a/src/renderer/lib/directoryTree.js
+++ b/src/renderer/lib/directoryTree.js
@@ -1,10 +1,35 @@
 const FS = require('fs');
 const PATH = require('path');
+const Delta = require('quill-delta');
+const Quill = require('quill');
+const { remote } = require('electron');
+
 
 const constants = {
   DIRECTORY: 'directory',
   FILE: 'file',
 };
+
+const notificationStore = (function store() {
+  let notifications = []; // Private Variable
+
+  const publicInterface = {};
+
+  publicInterface.add = function add(n) {
+    notifications.push(n);
+  };
+
+  publicInterface.getAll = function getAll() {
+    console.log(notifications.join('\n'));
+    return notifications.join('\n');
+  };
+
+  publicInterface.clear = function clear() {
+    notifications = [];
+  };
+
+  return publicInterface;
+}());
 
 function safeReadDirSync(path) {
   let dirData = {};
@@ -47,6 +72,18 @@ function directoryTree(path, options, onEachFile) {
     // Skip if it does not match the extension regex
     if (options && options.extensions && !options.extensions.test(ext)) { return null; }
 
+    try {
+      // Check for valid JSON
+      const contents = FS.readFileSync(path).toString();
+      const delta = new Delta(JSON.parse(contents));
+      const quill = new Quill('.hidden-editor');
+      quill.setContents(delta, 'silent');
+    } catch (error) {
+      console.warn(`${path} is corrupted`);
+      notificationStore.add(name);
+      return null;
+    }
+
     item.extension = ext;
     item.type = constants.FILE;
     if (onEachFile) {
@@ -57,7 +94,11 @@ function directoryTree(path, options, onEachFile) {
     if (dirData === null) return null;
 
     item.children = dirData
-      .map(child => directoryTree(PATH.join(path, child), options, onEachFile))
+      .map(child => directoryTree(
+        PATH.join(path, child),
+        { ...options, callFromRootDir: false },
+        onEachFile,
+      ))
       .filter(e => !!e)
       .sort((a, b) => {
         if (a.type === b.type) { if (a.path < b.path) { return -1; } return 1; }
@@ -67,6 +108,15 @@ function directoryTree(path, options, onEachFile) {
     item.type = constants.DIRECTORY;
   } else {
     return null; // Or set item.size = 0 for devices, FIFO and sockets ?
+  }
+  if (options.fileCorruptedNotification && options.callFromRootDir) {
+    const notification = new remote.Notification({
+      title: 'Opus Notification',
+      subtitle: 'One or more .note files in the selected directory are corrupted.',
+      body: `One or more .note files in the selected directory are corrupted.\n${notificationStore.getAll()}`,
+    });
+    notification.show();
+    notificationStore.clear();
   }
   return item;
 }

--- a/src/renderer/sidebar.js
+++ b/src/renderer/sidebar.js
@@ -100,7 +100,7 @@ module.exports = {
 
       watcher.on('all', (() => {
         // Update the document object tree
-        tree.reload(activeProject);
+        tree.reload(activeProject, false);
 
         // Update the DOM with new data (preserves open states)
         treeView.reload([tree.data], 'tree');

--- a/src/renderer/store.js
+++ b/src/renderer/store.js
@@ -20,17 +20,11 @@ const Store = {
     return settings.has(`windows.${this.path}.${key}`);
   },
 
-  getWithoutPath: (key) => {
-    return settings.get(`windows.${key}`);
-  },
+  getWithoutPath: key => settings.get(`windows.${key}`),
 
-  setWithoutPath: (key, value) => {
-    return settings.set(`windows.${key}`, value);
-  },
+  setWithoutPath: (key, value) => settings.set(`windows.${key}`, value),
 
-  hasWithoutPath: (key) => {
-    return settings.has(`windows.${key}`);
-  },
+  hasWithoutPath: key => settings.has(`windows.${key}`),
 };
 
 Object.freeze(Store);

--- a/src/renderer/tree.js
+++ b/src/renderer/tree.js
@@ -6,12 +6,14 @@ const tree = {
   data: null,
 };
 
-const update = function getUpdatedProjectTree(p) {
+const update = function getUpdatedProjectTree(p, fileCorruptedNotification) {
   if (!p || p === '') { throw new Error('Path cannot be empty.'); }
 
   tree.data = null;
   tree.data = dirTree(p, {
     extensions: /\.note/,
+    fileCorruptedNotification,
+    callFromRootDir: true,
   });
   tree.data.root = true;
 };
@@ -95,7 +97,7 @@ const applySettings = function applyExtendedPropToFolders(paths) {
   tree.data = unflatten(o);
 };
 
-const reload = function reloadDocumentTree(p) {
+const reload = function reloadDocumentTree(p, fileCorruptedNotification = true) {
   // Deep copy and flatten the tree object
   const old = flatten(JSON.parse(JSON.stringify(tree)).data);
 
@@ -118,7 +120,7 @@ const reload = function reloadDocumentTree(p) {
   });
 
   // Update the tree object
-  tree.update(p);
+  tree.update(p, fileCorruptedNotification);
 
   // Flatten the updated tree object
   const o = flatten(tree.data);
@@ -147,7 +149,7 @@ module.exports = {
     tree.reload = reload;
     tree.getSettings = getSettings;
     tree.applySettings = applySettings;
-    tree.update(p);
+    tree.update(p, true);
 
     if (paths && paths.length !== 0) {
       tree.applySettings(paths);


### PR DESCRIPTION
Fixes #1 

When there are corrupted files in the selected directory, those files will not be added to the sidebar. A notification will appear saying there are corrupted files.